### PR TITLE
CORS filter to allow calls from different ports / urls

### DIFF
--- a/src/main/java/ch/zhaw/robopatrol/CORSFilter.java
+++ b/src/main/java/ch/zhaw/robopatrol/CORSFilter.java
@@ -1,6 +1,5 @@
 package ch.zhaw.robopatrol;
 
-import java.io.IOException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -10,13 +9,10 @@ import javax.ws.rs.ext.Provider;
 public class CORSFilter implements ContainerResponseFilter {
 
     @Override
-    public void filter(ContainerRequestContext request,
-            ContainerResponseContext response) throws IOException {
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) {
         response.getHeaders().add("Access-Control-Allow-Origin", "*");
-        response.getHeaders().add("Access-Control-Allow-Headers",
-                "origin, content-type, accept, authorization");
+        response.getHeaders().add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization");
         response.getHeaders().add("Access-Control-Allow-Credentials", "true");
-        response.getHeaders().add("Access-Control-Allow-Methods",
-                "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+        response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
     }
 }

--- a/src/main/java/ch/zhaw/robopatrol/CORSFilter.java
+++ b/src/main/java/ch/zhaw/robopatrol/CORSFilter.java
@@ -1,0 +1,22 @@
+package ch.zhaw.robopatrol;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class CORSFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext request,
+            ContainerResponseContext response) throws IOException {
+        response.getHeaders().add("Access-Control-Allow-Origin", "*");
+        response.getHeaders().add("Access-Control-Allow-Headers",
+                "origin, content-type, accept, authorization");
+        response.getHeaders().add("Access-Control-Allow-Credentials", "true");
+        response.getHeaders().add("Access-Control-Allow-Methods",
+                "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+    }
+}

--- a/src/main/java/ch/zhaw/robopatrol/RobopatrolServer.java
+++ b/src/main/java/ch/zhaw/robopatrol/RobopatrolServer.java
@@ -15,6 +15,7 @@ public class RobopatrolServer extends ResourceConfig {
 
         packages("ch.zhaw.robopatrol.res");
         register(ExceptionListener.class);
+        register(CORSFilter.class);
     }
 
     /** Log exceptions. */

--- a/src/test/java/ch/zhaw/robopatrol/CORSFilterTest.java
+++ b/src/test/java/ch/zhaw/robopatrol/CORSFilterTest.java
@@ -1,0 +1,44 @@
+package ch.zhaw.robopatrol;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CORSFilterTest {
+
+    @Spy
+    private CORSFilter filter = new CORSFilter();
+
+    @Mock
+    private ContainerRequestContext request;
+
+    @Mock
+    private ContainerResponseContext response;
+
+    @Test
+    public void filter() {
+        MultivaluedMap<String, Object> responseHeaders = new MultivaluedHashMap<>();
+        when(response.getHeaders()).thenReturn(responseHeaders);
+
+        filter.filter(request, response);
+
+        assertThat(responseHeaders.get("Access-Control-Allow-Origin"), not(nullValue()));
+        assertThat(responseHeaders.get("Access-Control-Allow-Headers"), not(nullValue()));
+        assertThat(responseHeaders.get("Access-Control-Allow-Credentials"), not(nullValue()));
+        assertThat(responseHeaders.get("Access-Control-Allow-Methods"), not(nullValue()));
+    }
+
+}


### PR DESCRIPTION
I had to add a CORS filter to allow requests coming from a different domain (webapp runs on a different port than the server, which is considerate a separate domain).
Currently allows any origin, could be changed if we know for sure where the webapp will be running.
