### PR TITLE
RP-61 Run Gradle build during Docker build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+build/
+store/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM java:8
-# Can't use 8-alpine because the start script requires bash.
 
-# Run `gradle build` before running this Docker build! 
-ADD build/distributions/robopatrol-server.tar .
+ADD . robopatrol-server
 WORKDIR robopatrol-server
+
 VOLUME /robopatrol-server/store
-CMD ./bin/robopatrol-server
+RUN ./gradlew installDist
+
+CMD ./build/install/robopatrol-server/bin/robopatrol-server
 EXPOSE 9998


### PR DESCRIPTION
This builds the application inside the container.
Previously we had to run the Gradle build manually,
before building the Docker image.

Now just run: `docker-compose up` (or `docker-compose build`)
To publish an image: `docker build -t robopatrol/server . && docker push
robopatrol/server`
